### PR TITLE
grails-plugin-testing no longer supported

### DIFF
--- a/profile.yml
+++ b/profile.yml
@@ -32,5 +32,6 @@ dependencies:
         - "org.grails:grails-web-boot"
         - "org.grails:grails-logging"
     testCompile:
-        - "org.grails:grails-plugin-testing"
+        - "org.grails:grails-web-testing-support"
+        - "org.grails:grails-gorm-testing-support"
         - "io.micronaut:micronaut-http-client:1.0.3"


### PR DESCRIPTION
Replace grails-plugin-testing with following:
 - "org.grails:grails-web-testing-support"
 - "org.grails:grails-gorm-testing-support"

Fixes grails/grails-core#11456