### PR TITLE
Correct Grails async dependency

### DIFF
--- a/profile.yml
+++ b/profile.yml
@@ -28,7 +28,7 @@ dependencies:
         - "org.grails:grails-plugin-services"        
         - "org.grails:grails-plugin-datasource"
         - "org.grails:grails-plugin-databinding"
-        - "org.grails:grails-plugin-async"
+        - "org.grails.plugins:async"
         - "org.grails:grails-web-boot"
         - "org.grails:grails-logging"
     testCompile:


### PR DESCRIPTION
Replace the dependency grails-plugin-async with async in compile scope.

Fixes grails/grails-core#11456 and  #2 